### PR TITLE
Requires ember-cli-babel as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
     "ember-cli": "0.1.15",
-    "ember-cli-6to5": "^3.0.0",
     "ember-cli-app-version": "0.3.1",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.7",
@@ -40,5 +39,8 @@
   ],
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "dependencies": {
+    "ember-cli-babel": "^4.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-islands",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "Render Ember components 'outside' of an Ember application to create 'Islands of Richness' in a server-rendered application.",
   "directories": {
     "test": "tests"


### PR DESCRIPTION
This fix is to address the use of ES6 features in the addon.

Specifically [this line](https://github.com/mitchlloyd/ember-islands/blob/master/addon/render-components.js#L13) was causing issues in Safari because it does not currently support ES6 string interpolation.

Ember CLI recently added support for ES6 syntax to be supported in addons. The details can be discerned from these two pull requests:

1. https://github.com/ember-cli/ember-cli/pull/3166
2. https://github.com/ember-cli/ember-cli/issues/3556

