### PR TITLE
Save the component instance on the parent element

### DIFF
--- a/addon/render-components.js
+++ b/addon/render-components.js
@@ -12,9 +12,10 @@ export function getRenderComponentFor(application) {
     var component = componentLookup.lookupFactory(name, container);
     assert(`ember-islands could not find a component named "${name}" in your Ember appliction.`, component);
 
+    var $element = $(element);
     // Temporary fix for bug in `replaceIn`
-    $(element).empty();
-    component.create(attributes).appendTo(element);
+    $element.empty();
+    $element.data('component-instance', component.create(attributes).appendTo(element));
   };
 }
 


### PR DESCRIPTION
I'm not sure if this is something that should exist in this package or if it's the best way to do it.
However, I wanted a easy way to access the instantiated components from my old app (rails + jquery) to be able to destroy the components so I can render new once.

So basically I have an initializer in my ember app:
```js
import renderComponents from 'ember-islands/render-components';

export function initialize(container, application) {
  window.renderComponents = function(){
    renderComponents(application);
  };

  window.destroyComponents = function(){
    $('[data-component]').each(function(){
      $(this).data('component-instance').destroy();
    });
  };
}
```

And then I have a list with components that get replaced with old school ajax:
```js
window.destroyComponents();
$("#wrapper").html(data.html);
window.renderComponents();
```

Maybe this could be helpful for someone, even if it's not merged.

Thanks again for the work on ember-island!