### PR TITLE
Ember 2.7 support

### DIFF
--- a/addon/components/ember-islands.js
+++ b/addon/components/ember-islands.js
@@ -38,10 +38,10 @@ function componentAttributes(element) {
 }
 
 function getRenderComponentFor(emberObject) {
-  let componentLookup = getOwner(emberObject).lookup('component-lookup:main');
+  let owner = getOwner(emberObject);
 
   return function renderComponent({ name, attrs, element }) {
-    let component = componentLookup.lookupFactory(name);
+    let component = lookupComponent(owner, name);
     assert(`ember-islands could not find a component named "${name}" in your Ember appliction.`, component);
 
     // Work around for #replaceIn bug
@@ -62,4 +62,17 @@ function queryIslandComponents() {
   });
 
   return components;
+}
+
+function lookupComponent(owner, name) {
+  let componentLookupKey = `component:${name}`;
+  let layoutLookupKey = `template:components/${name}`;
+  let layout = owner.lookup(layoutLookupKey);
+
+  if (layout) {
+    owner.inject(componentLookupKey, 'layout', layoutLookupKey);
+  }
+
+  let component = owner._lookupFactory(componentLookupKey);
+  return component;
 }

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-islands",
   "dependencies": {
-    "ember": "~2.1.0",
+    "ember": "~2.7.0",
     "ember-cli-shims": "0.0.6",
     "ember-cli-test-loader": "0.2.1",
     "ember-load-initializers": "0.1.7",
@@ -13,6 +13,6 @@
     "qunit": "~1.20.0"
   },
   "resolutions": {
-    "ember": "~2.1.0"
+    "ember": "~2.7.0"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -23,13 +23,19 @@ module.exports = {
       }
     },
     {
-      name: 'ember-canary',
+      name: 'ember-2.7',
       dependencies: {
-        "ember": "components/ember#canary"
-      },
-      resolutions: {
-        "ember": "canary"
+        "ember": "~2.7.0"
       }
-    }
+    },
+    // {
+    //   name: 'ember-canary',
+    //   dependencies: {
+    //     "ember": "components/ember#canary"
+    //   },
+    //   resolutions: {
+    //     "ember": "canary"
+    //   }
+    // }
   ]
 };


### PR DESCRIPTION
[A little cleanup](https://github.com/emberjs/ember.js/commit/7b925e31bd952f3c8a83cd2cd64cf622c7d26b32) for the new 2.7 release left us without a lookupComponent method. Here I'm taking matters into my own hands and using the container names for the template and the component. Hopefully this will be a little more resilient. 

Interesting to note that `component.destroy()` not longer removes a component from the DOM in Canary, so I've commented that out for now. Sure to be a lot of changes on canary with Glimmer 2 on the way.