### PR TITLE
Add compatibility for Ember canary

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -28,14 +28,14 @@ module.exports = {
         "ember": "~2.7.0"
       }
     },
-    // {
-    //   name: 'ember-canary',
-    //   dependencies: {
-    //     "ember": "components/ember#canary"
-    //   },
-    //   resolutions: {
-    //     "ember": "canary"
-    //   }
-    // }
+    {
+      name: 'ember-canary',
+      dependencies: {
+        "ember": "components/ember#canary"
+      },
+      resolutions: {
+        "ember": "canary"
+      }
+    }
   ]
 };


### PR DESCRIPTION
This could probably be merged in, but there is one very minor change from using `didDestroyElement` to using `willDestroyElement`.  Opened [an issue in Ember](https://github.com/emberjs/ember.js/issues/14185) to fix this. 