### PR TITLE
Introduces ember-outlet

### DIFF
--- a/addon/components/island-outlet.js
+++ b/addon/components/island-outlet.js
@@ -1,0 +1,30 @@
+import Ember from 'ember';
+import WormholeComponent from 'ember-wormhole/components/ember-wormhole';
+
+const {
+  assert,
+  Component,
+  computed,
+  getOwner,
+  guidFor
+} = Ember;
+
+const Outlet = WormholeComponent.extend({
+  classNames: ['island-outlet'],
+  destinationElement: computed('outletName', {
+    get() {
+      let name = this.get('outletName');
+      assert('An outlet name is mandatory', name);
+      let $element = $(`[data-outlet="${name}"]`);
+      assert(`No outlet found with the name "${name}"`, $element.length !== 0);
+      assert(`Multiple outlets with the name "${name}"`, $element.length === 1);
+      return $element.get(0);
+    }
+  }).readOnly()
+});
+
+Outlet.reopenClass({
+  positionalParams: ['outletName']
+});
+
+export default Outlet;

--- a/app/components/island-outlet.js
+++ b/app/components/island-outlet.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-islands/components/island-outlet';

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "ujs"
   ],
   "dependencies": {
-    "ember-getowner-polyfill": "1.0.0"
+    "ember-getowner-polyfill": "1.0.0",
+    "ember-wormhole": "0.5.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -15,6 +15,7 @@
     {{content-for 'head-footer'}}
   </head>
   <body>
+    <div data-outlet="main"></div>
     {{content-for 'body'}}
 
     <p>Some static content in the index page</p>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,1 +1,4 @@
 {{dummy-application}}
+{{#island-outlet "main"}}
+  Yay
+{{/island-outlet}}

--- a/tests/integration/components/island-outlet-test.js
+++ b/tests/integration/components/island-outlet-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('island-outlet', 'Integration | Component | island outlet', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
+
+  this.render(hbs`{{island-outlet}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:" + EOL +
+  this.render(hbs`
+    {{#island-outlet}}
+      template block text
+    {{/island-outlet}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
⚠️ WIP - tests missing

My apologies if that has already been discussed.

This PR introduces the concept of `island-outlet`. An `island-outlet` behaves like a typical outlet: it is a named placeholder for content. It allows to define in the DOM a number of locations for which the content will be dictated by the blocks yielded within the `{{island-outlet}}` components with the same name.

As an example, here's the HTML I had to deal with:

```html
<div id="ember-application">
  <div data-component="app-navbar"/>
  <div class="container">
    <!-- 
           Here we want to display the contents of the route template here
           instead of a specific component.
           For this, we use `[data-outlet="main-outlet"]` below
    -->
    <div data-outlet="main-outlet"/>
  </div>
  <div data-component="app-footer"/>
</div>
```

and the following `application.hbs`:
```hbs
{{outlet}}
{{ember-islands}}
```

Without using `{{ember-outlet}}`, I can not have the `{{outlet}}` to render at the correct place in the document (it will append to `#ember-application`).

With this PR, I can rewrite the template as follows:
```hbs
{{#island-outlet "main-outlet"}}
  {{outlet}}
{{/island-outlet}}
{{ember-islands}}
```

and see my outlet rendered at the expected place.

If you welcome the idea, there's a lot of room for discussion and improvement (notably regarding the dependency of ember-wormhole), but for the moment, I simply wanted to share a draft on the concept.

Hope you'll like it!