### PR TITLE
Keep rendering components after error in prod

### DIFF
--- a/addon/components/ember-islands.js
+++ b/addon/components/ember-islands.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-const { $, assert, Component, getOwner } = Ember;
+const { $, Component, getOwner, Logger } = Ember;
 
 export default Ember.Component.extend({
   tagName: '',
@@ -41,7 +41,12 @@ function getRenderComponentFor(emberObject) {
 
   return function renderComponent({ name, attrs, element }) {
     let { component, layout } = lookupComponent(owner, name);
-    assert(`ember-islands could not find a component named "${name}" in your Ember appliction.`, component);
+    Ember.assert(missingComponentMessage(name), component);
+
+    // This can only be true in production mode where assert is a no-op.
+    if (!component) {
+      ({ component, layout } = provideMissingComponentInProductionMode(owner, name));
+    }
 
     if (layout) {
       attrs.layout = layout;
@@ -78,4 +83,14 @@ function lookupComponent(owner, name) {
   }
 
   return { component, layout };
+}
+
+function missingComponentMessage(name) {
+  return `ember-islands could not find a component named "${name}" in your Ember appliction.`;
+}
+
+function provideMissingComponentInProductionMode(owner, name) {
+  Logger.error(missingComponentMessage(name));
+
+  return lookupComponent(owner, 'ember-islands/missing-component');
 }

--- a/addon/components/ember-islands.js
+++ b/addon/components/ember-islands.js
@@ -86,7 +86,7 @@ function lookupComponent(owner, name) {
 }
 
 function missingComponentMessage(name) {
-  return `ember-islands could not find a component named "${name}" in your Ember appliction.`;
+  return `ember-islands could not find a component named "${name}" in your Ember application.`;
 }
 
 function provideMissingComponentInProductionMode(owner, name) {

--- a/app/components/ember-islands/missing-component.js
+++ b/app/components/ember-islands/missing-component.js
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend();

--- a/tests/acceptance/missing-component-test.js
+++ b/tests/acceptance/missing-component-test.js
@@ -43,6 +43,6 @@ test('rendering the found component', function(assert) {
 
   andThen(function() {
     assert.equal(find('p:contains(top level component)').length, 1, "The top level component was rendered");
-    assert.deepEqual(errors, [`ember-islands could not find a component named "oops-not-component" in your Ember appliction.`], 'Logs an error');
+    assert.deepEqual(errors, [`ember-islands could not find a component named "oops-not-component" in your Ember application.`], 'Logs an error');
   });
 });

--- a/tests/acceptance/missing-component-test.js
+++ b/tests/acceptance/missing-component-test.js
@@ -1,0 +1,48 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../helpers/start-app';
+
+let application, originalAssert, originalError, errors;
+
+module('Acceptance: Dealing with missing components in production', {
+  beforeEach: function() {
+    // Put some static content on the page before the Ember application loads.
+    // This mimics server-rendered content.
+    document.getElementById('ember-testing').innerHTML = `
+      <div data-component='oops-not-component' data-attrs='{"title": "Component Title"}'></div>
+      <div data-component='top-level-component'></div>
+    `;
+
+    // Replace Ember's `assert` function with a no-op. This mirrors Ember's
+    // behavior in production mode.
+    originalAssert = Ember.assert;
+    Ember.assert = () => {};
+
+    // Replace Ember's Logger.error with a fake that records the errors.
+    originalError = Ember.Logger.error;
+    errors = [];
+    Ember.Logger.error = (message) => {
+      errors.push(message);
+    };
+
+    application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.assert = originalAssert;
+    Ember.Logger.error = originalError;
+
+    Ember.run(application, 'destroy');
+    document.getElementById('ember-testing').innerHTML = '';
+  }
+});
+
+test('rendering the found component', function(assert) {
+  assert.expect(2);
+  visit('/');
+
+  andThen(function() {
+    assert.equal(find('p:contains(top level component)').length, 1, "The top level component was rendered");
+    assert.deepEqual(errors, [`ember-islands could not find a component named "oops-not-component" in your Ember appliction.`], 'Logs an error');
+  });
+});


### PR DESCRIPTION
In production mode, don't stop rendering components after finding that
one is missing. Instead render a no-op (but overridable component) and
log an error. 

[fix #36]

@patric-eberle could you try this branch out?

I think this can be a minor release but I'm not sure. There is a chance that someone could be using the error message from Ember Islands in production mode by extending the ember-islands component and overriding the `didInsertElement` hook. 