### PR TITLE
Removed dependence on jQuery except in tests

### DIFF
--- a/addon/utils/get-render-component.js
+++ b/addon/utils/get-render-component.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-const { getOwner, Component, Logger, $ } = Ember;
+const { getOwner, Component, Logger } = Ember;
 
 export default function getRenderComponent(emberObject) {
   let owner = getOwner(emberObject);
@@ -17,7 +17,7 @@ export default function getRenderComponent(emberObject) {
       attrs.layout = layout;
     }
 
-    $(element).empty();
+    while (element.firstChild) { element.removeChild(element.firstChild); }
     let componentInstance = component.create(attrs);
     componentInstance.appendTo(element);
 

--- a/addon/utils/query-island-components.js
+++ b/addon/utils/query-island-components.js
@@ -1,6 +1,3 @@
-import Ember from 'ember';
-const { $ } = Ember;
-
 /**
  * @typedef {object} IslandComponent
  * @property {object} element - The placeholder element for this component
@@ -15,10 +12,10 @@ const { $ } = Ember;
 export default function queryIslandComponents() {
   let components = [];
 
-  $('[data-component]').each(function() {
-    let name = this.getAttribute('data-component');
-    let attrs = componentAttributes(this);
-    components.push({ attrs, name, element: this, instance: undefined });
+  document.querySelectorAll('[data-component]').forEach(function(component) {
+    let name = component.getAttribute('data-component');
+    let attrs = componentAttributes(component);
+    components.push({ attrs, name, element: component, instance: undefined });
   });
 
   return components;

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.5.0",
     "ember-source": "^2.16.0",
+    "jquery": "^3.3.0",
     "loader.js": "^4.0.10"
   },
   "engines": {

--- a/tests/dummy/app/components/js-only-component.js
+++ b/tests/dummy/app/components/js-only-component.js
@@ -6,6 +6,6 @@ export default Component.extend({
   classNames: ['js-only-component'],
 
   onDidInsertElement() {
-    this.$().html('js-only-component');
+    this.element.innerHTML = 'js-only-component';
   }
 });


### PR DESCRIPTION
Since Ember itself seems to be moving away from the use of jQuery in the core library, this PR goes ahead and removes the dependence for the main addon (though I didn't remove it from tests). This allows using ember-islands with a project that doesn't otherwise include (or want to include) jQuery.